### PR TITLE
make valid ctrl-c for run

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,5 @@ features (in the future):
 * [ ] Add registration task with dependency directory
 * [ ] Add notifier (slack, line notify, sidekiq)
 * [ ] Add documentation
-* [ ] Fix Ctrl-C problem for asyncio.sleep
 * [ ] Make worker daemon process 
 * [ ] Add Test

--- a/drudgeyer/run.py
+++ b/drudgeyer/run.py
@@ -24,11 +24,13 @@ def main(
     queue_ = QUEUE_CLASSES[queue]()
     logger_ = LOGGER_CLASSES[logger]()
 
-    try:
-        loop = asyncio.get_event_loop()
-        if http:
-            loop.create_task(run_receiver(loop))
-        loop.run_until_complete(Worker(logger_, queue_, freq=frequency)._run(loop))
-    except KeyboardInterrupt:
-        loop.close()
-        return
+    loop = asyncio.get_event_loop()
+    loop.set_debug(False)
+
+    worker = Worker(logger_, queue_, freq=frequency)
+
+    if http:
+        server = run_receiver(loop, [worker.handle_exit])
+        loop.create_task(server.serve())
+
+    loop.run_until_complete(worker._run(loop))

--- a/drudgeyer/tools/logger.py
+++ b/drudgeyer/tools/logger.py
@@ -7,7 +7,7 @@ from typing import Dict, Type
 
 class BaseLog(ABC):
     @abstractmethod
-    def intro(self, command: str) -> None:
+    def reset(self, id: str, command: str) -> None:
         ...
 
     @abstractmethod
@@ -29,7 +29,7 @@ class BaseLog(ABC):
 
 
 class PrintLogger(BaseLog):
-    def intro(self, command: str) -> None:
+    def reset(self, id: str, command: str) -> None:
         sys.stdout.write('\nTask: "' + command + '"\n')
 
     def output(self, input: bytes) -> None:

--- a/drudgeyer/tools/queue.py
+++ b/drudgeyer/tools/queue.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 class BaseQueue(ABC):
     @abstractmethod
-    def dequeue(self) -> Optional[str]:
+    def dequeue(self) -> Optional[BaseQueueModel]:
         ...
 
     @abstractmethod
@@ -29,7 +29,7 @@ class BaseQueue(ABC):
         ...
 
     @abstractmethod
-    def list(self) -> List["QueueModel"]:
+    def list(self) -> List[BaseQueueModel]:
         ...
 
     @abstractmethod
@@ -52,7 +52,7 @@ class FileQueue(BaseQueue):
         with file.open("w") as f:
             f.write(cmd)
 
-    def dequeue(self) -> Optional[str]:
+    def dequeue(self) -> Optional[BaseQueueModel]:
         files = list(self.path.glob("*-*-*-*-*-*-*"))
         if not files:
             return None
@@ -67,9 +67,9 @@ class FileQueue(BaseQueue):
         with target.open() as f:
             cmd = f.read()
         target.rename("done/" + target.name)
-        return cmd
+        return BaseQueueModel(id=target.name, command=cmd, order=0)
 
-    def list(self) -> List["QueueModel"]:
+    def list(self) -> List[BaseQueueModel]:
         files = list(self.path.glob("*-*-*-*-*-*-*"))
         if not files:
             return []

--- a/drudgeyer/tools/receiver.py
+++ b/drudgeyer/tools/receiver.py
@@ -1,6 +1,9 @@
 import asyncio
+import logging
+import signal
 from pathlib import Path
-from typing import Any, Coroutine
+from types import FrameType
+from typing import Callable, List, Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -21,7 +24,22 @@ async def add_task(body: Command) -> None:
         f.write(body.cmd)
 
 
-def run_receiver(event_loop: asyncio.AbstractEventLoop) -> Coroutine[Any, Any, Any]:
-    config = Config(app=app, loop=event_loop)
-    server = Server(config)
-    return server.serve()
+def run_receiver(
+    event_loop: asyncio.AbstractEventLoop,
+    handlers: List[Callable[[signal.Signals, Optional[FrameType]], None]],
+) -> Server:
+    """
+    NOTE: Uvicorn override signal handler for eventloop in the case of "ctrl-c" and "kill pid".
+    So, tasks in eventloop other than "Uvicorn" cannot exit if "ctrl-c" and "kill pid".
+    To solve it, inject signal handler for other tasks.
+    """
+
+    class SubServer(Server):  # type: ignore
+        def handle_exit(self, sig: signal.Signals, frame: Optional[FrameType]) -> None:
+            super().handle_exit(sig, frame)
+            for handler in handlers:
+                handler(sig, frame)
+
+    config = Config(app=app, loop=event_loop, log_level=logging.ERROR)
+    server = SubServer(config)
+    return server

--- a/drudgeyer/tools/shell.py
+++ b/drudgeyer/tools/shell.py
@@ -1,57 +1,49 @@
 import asyncio
 from abc import ABC, abstractmethod
 from asyncio.subprocess import PIPE, STDOUT, create_subprocess_shell
-from typing import Any
+from signal import Signals
+from types import FrameType
+from typing import Any, Optional
 
 from drudgeyer.tools.logger import BaseLog
-from drudgeyer.tools.queue import BaseQueue
+from drudgeyer.tools.queue import BaseQueue, BaseQueueModel
 
 
 class BaseWorker(ABC):
     def __init__(self, freq: float = 1):
         self.freq = freq
+        self.should_exit: bool = False
+        self.force_exit: bool = False
 
     async def _run(self, loop: asyncio.AbstractEventLoop) -> None:
-        while True:
-            task = await self.dequeue()
-            if task:
-                await self.run(task, loop)
-            else:
-                await asyncio.sleep(self.freq)
-            await asyncio.sleep(self.freq)
+        try:
+            while not self.should_exit:
+                task = await self.dequeue()
+                if self.should_exit:
+                    return
+                if task:
+                    await self.run(task, loop)
+                else:
+                    await asyncio.sleep(self.freq)
+
+                if not self.should_exit:
+                    await asyncio.sleep(self.freq)
+        except asyncio.CancelledError as e:
+            return
 
     @abstractmethod
-    async def dequeue(self) -> Any:
+    async def dequeue(self) -> BaseQueueModel:
         ...
 
     @abstractmethod
-    async def run(self, task: Any, loop: asyncio.AbstractEventLoop) -> None:
+    async def run(self, task: BaseQueueModel, loop: asyncio.AbstractEventLoop) -> None:
         ...
 
-
-async def run_shell_command(
-    command: str, logger: BaseLog, loop: asyncio.AbstractEventLoop
-) -> int:
-    try:
-        process = await create_subprocess_shell(
-            command,
-            stdout=PIPE,
-            stderr=STDOUT,
-            loop=loop,
-        )
-        if process.stdout:
-            asyncio.create_task(logger._output(process.stdout))
-
-        exitcode = await process.wait()  # 0 means success
-
-    except (OSError, FileNotFoundError, PermissionError) as exception:
-        logger.exception(exception)
-        return 1
-    else:
-        # no exception was raised
-        logger.finish()
-
-    return exitcode
+    def handle_exit(self, sig: Signals, frame: Optional[FrameType]) -> None:
+        if self.should_exit:
+            self.force_exit = True
+        else:
+            self.should_exit = True
 
 
 class Worker(BaseWorker):
@@ -65,6 +57,29 @@ class Worker(BaseWorker):
     async def dequeue(self) -> Any:
         return self._queue.dequeue()
 
-    async def run(self, task: str, loop: asyncio.AbstractEventLoop) -> None:
-        self._logger.intro(task)
-        await run_shell_command(task, self._logger, loop)
+    async def run(self, task: BaseQueueModel, loop: asyncio.AbstractEventLoop) -> None:
+        # TODO: add safe terminate process for subprocess shell
+        self._logger.reset(task.id, task.command)
+
+        if self.should_exit:
+            return
+
+        command = task.command
+        try:
+            process = await create_subprocess_shell(
+                command,
+                stdout=PIPE,
+                stderr=STDOUT,
+                loop=loop,
+            )
+            if process.stdout:
+                asyncio.create_task(self._logger._output(process.stdout))
+
+            exitcode = await process.wait()  # 0 means success
+
+        except (OSError, FileNotFoundError, PermissionError) as exception:
+            self._logger.exception(exception)
+            exitcode = 1
+        else:
+            # no exception was raised
+            self._logger.finish()


### PR DESCRIPTION
Resolved:

* [x] Fix Ctrl-C problem for asyncio.sleep

In eventloop, signal (ctrl-c or kill pid) send to "signal handler", handler "can" do something to terminate each tasks.
However "Uvicorn" overrides signal handler with that terminate only uvicorn server (unfortunatly as well, if uvicorn server has stopped already).
That is the reason why Ctrl-c is ignored.

My resolution is that re-override signal handler and inject terminating process for other tasks.