### PR TITLE
Get log record for log-tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ features (in the future):
 
 * [x] Add file logger
 * [ ] Add DB (SQLite3), Redis Queue
-* [ ] Add Log tracker
+* [x] Add Log tracker
 * [x] Add registration task with dependency directory
 * [ ] Add notifier (slack, line notify, sidekiq)
 * [ ] Add documentation

--- a/drudgeyer/cli/add.py
+++ b/drudgeyer/cli/add.py
@@ -27,5 +27,8 @@ def main(
     dep = CopyDep(directory, BASEDIR / "dep")
     queue_ = QUEUE_CLASSES[queue](path=BASEDIR / "queue", depends=dep)
 
-    queue_.enqueue(command)
-    typer.secho(f"Queued: {command}", fg=typer.colors.CYAN)
+    item = queue_.enqueue(command)
+    typer.secho(
+        f"Queued:\n- Order: {item.order}\n- ID: {item.id}\n- Command: {item.command}\n- Workdir: {item.workdir}",
+        fg=typer.colors.CYAN,
+    )

--- a/drudgeyer/cli/log.py
+++ b/drudgeyer/cli/log.py
@@ -8,7 +8,7 @@ async def entry_point(uri: str) -> None:
     try:
         async with websockets.connect(uri) as websocket:
             async for msg in websocket:
-                typer.echo(msg)
+                typer.echo(msg, nl=False)
     except websockets.ConnectionClosedError:
         typer.secho("Connection closed", fg=typer.colors.RED)
     except OSError:
@@ -19,7 +19,7 @@ async def entry_point(uri: str) -> None:
 
 def main(
     id: str = typer.Argument(..., help="check task id using drudgeyer list"),
-    url: str = typer.Argument(..., help="log-tracker server URL"),
+    url: str = typer.Argument("127.0.0.1:8000", help="log-tracker server URL"),
 ) -> None:
     """Application: tracking task logs from log-tracker application
     For:

--- a/drudgeyer/job_scheduler/dependency.py
+++ b/drudgeyer/job_scheduler/dependency.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC, abstractmethod
 from pathlib import Path
 from shutil import copytree, rmtree
@@ -56,7 +57,14 @@ class CopyDep(BaseDep):
     def workdir(self, id: str) -> Path:
         if not id:
             raise ValueError()
-        return self.path / id
+        workdir = self.path / id
+        if self._target:
+            workdir = workdir / self._target.name
+        elif workdir.is_dir():
+            workdir = workdir / [f for f in os.listdir(workdir) if os.path.isdir(f)][0]
+        else:
+            workdir = Path("")
+        return workdir
 
     async def clear(self, id: str) -> None:
         if id:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ pytest-asyncio = "^0.14.0"
 pytest-timeout = "^1.4.2"
 requests = "^2.25.1"
 pytest-mock = "^3.5.1"
+tqdm = "^4.59.0"
 
 [tool.poetry.scripts]
 drudgeyer = "drudgeyer.__init__:app"

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -51,7 +51,7 @@ class DummyWebSocketClientProtcol:
 @pytest.mark.asyncio
 async def test_websockets_mock(mocker, capsys):
     websocket = mocker.patch("websockets.connect")
-    dummy_resp = "test"
+    dummy_resp = "test\n"
     repeat = 2
     websocket.return_value = DummyWebSocketClientProtcol(dummy_resp, repeat)
     await entry_point("")
@@ -62,7 +62,7 @@ async def test_websockets_mock(mocker, capsys):
 @pytest.mark.asyncio
 async def test_websockets_closed(mocker, capsys):
     websocket = mocker.patch("websockets.connect")
-    dummy_resp = "test"
+    dummy_resp = "test\n"
     repeat = 0
     exception = websockets.ConnectionClosedError(1008, "")
     websocket.return_value = DummyWebSocketClientProtcol(dummy_resp, repeat, exception)
@@ -74,7 +74,7 @@ async def test_websockets_closed(mocker, capsys):
 @pytest.mark.asyncio
 async def test_websockets_not_found(mocker, capsys):
     websocket = mocker.patch("websockets.connect")
-    dummy_resp = "test"
+    dummy_resp = "test\n"
     repeat = 0
     exception = OSError
     websocket.return_value = DummyWebSocketClientProtcol(dummy_resp, repeat, exception)
@@ -86,7 +86,7 @@ async def test_websockets_not_found(mocker, capsys):
 @pytest.mark.asyncio
 async def test_websockets_exception(mocker):
     websocket = mocker.patch("websockets.connect")
-    dummy_resp = "test"
+    dummy_resp = "test\n"
     repeat = 0
     exception = Exception
     websocket.return_value = DummyWebSocketClientProtcol(dummy_resp, repeat, exception)

--- a/tests/job_scheduler/test_dependency.py
+++ b/tests/job_scheduler/test_dependency.py
@@ -35,7 +35,7 @@ async def test_copydep():
 
         # get working directory to execute command
         workdir = dep.workdir("xxx")
-        assert workdir == (path / "xxx")
+        assert workdir == (path / "xxx" / "src")
 
         # delete dependency
         await dep.clear("xxx")


### PR DESCRIPTION
Add:

* Get log record for log-tracker: log-tracker (ReadStreamer) can stream only new log after connection. but this PR add feature to get "old" log record from file and concatenate with new log
* "tqdm" friendly: log-tracker client will be able to show tqdm-like output
* more robust working directory